### PR TITLE
importパスの参照

### DIFF
--- a/application/Quest.ts
+++ b/application/Quest.ts
@@ -1,4 +1,4 @@
-import { Quest } from "core";
+import { Quest } from "../core";
 
 /**
  * クエストを取得するリクエストのbody部。

--- a/core/Account/Avatar.ts
+++ b/core/Account/Avatar.ts
@@ -1,4 +1,4 @@
-import { Item } from "core";
+import { Item } from "../../core";
 
 /**
  * アバターの種族。

--- a/core/Account/User.test.ts
+++ b/core/Account/User.test.ts
@@ -1,6 +1,5 @@
-import { IAccountRepository } from "infrastructure";
-import { Avatar, Race } from "./Avatar";
-import { Player, User } from "./User";
+import { Avatar, Player, Race, User } from "../../core";
+import { IAccountRepository } from "../../infrastructure";
 
 describe("User's functionality", () => {
   test("password hashing", () => {

--- a/core/Account/User.ts
+++ b/core/Account/User.ts
@@ -1,6 +1,6 @@
-import { Avatar, Race } from "./Avatar";
+import { Avatar, Race } from "../../core";
 import crypto from "crypto";
-import { IAccountRepository } from "infrastructure";
+import { IAccountRepository } from "../../infrastructure";
 
 /**
  * ユーザーを代表する抽象クラス。

--- a/core/Quest/Item.ts
+++ b/core/Quest/Item.ts
@@ -1,4 +1,4 @@
-import { Effect, EffectOption } from "core";
+import { Effect, EffectOption } from "../../core";
 
 /**
  * アイテムを代表する抽象クラス。

--- a/core/Quest/Quest.ts
+++ b/core/Quest/Quest.ts
@@ -1,4 +1,4 @@
-import { Answer, Item } from "core";
+import { Answer, Item } from "../../core";
 
 /**
  * クエストを代表する抽象クラス。

--- a/infrastructure/index.ts
+++ b/infrastructure/index.ts
@@ -1,4 +1,4 @@
-import { Answer, Avatar, Item, Player, Quest, User } from "core";
+import { Answer, Avatar, Item, Player, Quest, User } from "../core";
 
 export type Identifier = string | number;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "module": "CommonJS",
-    "baseUrl": ".",
     "resolveJsonModule": true,
     "outDir": "dist",
     "removeComments": true,


### PR DESCRIPTION
tsconfigでbaseURLを設定することによって、
モジュールの参照パスは相対参照しなくて済むが、
その代わりに、参照先ではtsconfigにincludeを設定しなくてはならなくなる

それを解消するために、baseURLを取り消し、相対参照に戻す
