### PR TITLE
ci: ユニットテストCIを修正

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,14 +1,12 @@
 name: Unit Test with Jest
 
 on:
-  push:
-    branches: ["dev"]
   pull_request:
     branches: ["main", "dev"]
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -22,8 +20,10 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: "npm"
 
-      - name: Install & Test
-        run: |
-          npm ci
-          npm run test
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test project
+        run: npm run test


### PR DESCRIPTION
- 依存性をキャッシュ
- Repoが公開されたので、ランナーをセルフホストから離れる
- devに直接プッシュすることはないので、実行トリガーをPRのみにする